### PR TITLE
Handle slog.Any as string otel attributes

### DIFF
--- a/slog_otel.go
+++ b/slog_otel.go
@@ -212,7 +212,7 @@ func (h OtelHandler) slogAttrToOtelAttr(attr slog.Attr, groupKeys ...string) att
 		case []bool:
 			return attribute.BoolSlice(key, v)
 		default:
-			return attribute.KeyValue{}
+			return attribute.String(key, fmt.Sprintf("%+v", v))
 		}
 	default:
 		return attribute.KeyValue{}

--- a/slog_otel_test.go
+++ b/slog_otel_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"strings"
 	"testing"
@@ -127,6 +128,9 @@ func TestOtelHandler(t *testing.T) {
 		}, {
 			Key:   "group_2.key_2",
 			Value: attribute.StringValue("value_2"),
+		}, {
+			Key:   "err",
+			Value: attribute.StringValue("boom"),
 		}}
 
 		func() {
@@ -151,6 +155,7 @@ func TestOtelHandler(t *testing.T) {
 				"float64_slice", float64Slice,
 				"bool_slice", boolSlice,
 				"a_key", "a_value",
+				"err", errors.New("boom"),
 				group1,
 				group2,
 			)


### PR DESCRIPTION
Similar to how slog default text/JSON handlers deal with Any values: https://cs.opensource.google/go/go/+/master:src/log/slog/text_handler.go;drc=f09db2bb9331f4b31afb867173b1773e6494af27;l=119